### PR TITLE
Compose embedly_url using compose_url Gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ jekyll.
 
 ## How to install
 
-1. Make sure you have the _json_ and _domainatrix_ gems installed.
+1. Make sure you have the _json_, _domainatrix_ and _compose_url_ gems installed.
 2. Download the `embedly.rb` file and place it in the `_plugins/` inside your
    Jekyll project directory.
 3. Go to the embed.ly site, register an account and get your API key.
 4. Add your site address to the referrer section e.g. 'localhost.com*' or 'www.mywebsite.com*'
 5. Edit your `_config.yml` as described below.
-6. Make use of the new `embedly`-Liquid tag somewhere on your site.  
+6. Make use of the new `embedly`-Liquid tag somewhere on your site.
    E.g. `{% embedly  http://soundcloud.com/mightyoaksmusic/rainier %}`
 7. Compile your site.
 
@@ -57,7 +57,7 @@ embeds type, provider as well as the generic `embed`.
 E.g.
 
     {% embedly  http://soundcloud.com/mightyoaksmusic/rainier %}
-    
+
 will result in
 
     <div class="embed rich soundcloud">

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ You can further customize your embeds adding host-specific parameters.
       api_key: abcdefg123456780cafebabe101cat44
 
       soundcloud:
-        color: 0066FF # SoundCloud specific parameter for colorful players
         width: 500px
 
       vimeo:
         width: 500px
+        vimeo_color: FF0000
 
 You can also pass along parameters to individual embeds, e.g.
 

--- a/embedly.rb
+++ b/embedly.rb
@@ -6,10 +6,6 @@ require 'domainatrix'
 
 module Jekyll
   class Embedly < Liquid::Tag
-    @@EMBEDLY_PARAMETERS = ['maxwidth', 'maxheight', 'format', 'callback',
-                            'wmode', 'allowscripts', 'nostyle', 'autoplay',
-                            'videosrc', 'words', 'chars', 'width', 'height']
-
     def initialize(tag_name, text, tokens)
       super
 


### PR DESCRIPTION
I sat down to write this plugin but found it already written so well! I was excited it see it.

Upon using it I started having problems due to improperly formatted URLs. The query params always started with a `?` but sometimes switched back to a `?` from a `&` mid-URL. I had some progress already made towards a class that could easily be instantiated that made composing a URL with query parameters easier.  I figured I'd finish that project and incorporate it here. This abstracted the URL composition logic out of the plugin and solved the issue I was having. I tested thoroughly, but as it goes it could use another set of eyes.

There was an array of embedly-specific keys that I removed. The compuse_url gem escapes all values regardless. That comparison no longer seemed necessary.

I updated the README doc with some info that appears to be correct based on my testing and reading of the Embedly API doc. Embedly doesn't seem to support color for the SoundCloud player ... at least not right now. I'm pretty sure I didn't break this with my update and any other parameter option I test works. For example, `vimeo_color` works.

Here's my compose_url Gem that I added utilization of. https://github.com/ryanburnette/compose_url

Let me know what you think of the updates.

---

It might also be nice to make this a Gem itself. That would mean Jekyll users could add it to their Gemfile, automatically installing the dependencies and just adding a file in `_plugins` that requires the Gem, but that's for another day.
